### PR TITLE
Custom parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Parses an AST node against a schema and returns the parsed value if schema parsi
 
 ## API
 
-### Babel AST
+Zast is class-base/d. You need to create an instance with an optional context before using any parsers.
+Each Zast instance ships with a fixed set of basic parsers of following list.
 
 - `z.string()` matches any string and returns its value
 - `z.string('John')` matches any string with exact value "John" and returns its value
@@ -51,7 +52,43 @@ matches an **exact** object of shape:
 - `z.function()` matches any function
 
 - `z.or(schema[])` matches if any of the schemas match, the first match wins
+
   - `z.or(z.string(), z.number()).parse(SringLiternalNode)` passes and returns the string value
+
+- `z.custom` allows creating ad-hoc parsers.
+
+```ts
+const z: Zast = new Zast({
+  fileContent: 'const str = "pretend very long str"',
+});
+
+z.custom(
+  "inRangeString",
+  (
+    ctx,
+    node,
+    min: number = 0,
+    max: number = 50,
+    inclusive: boolean = false
+  ) => {
+    if (
+      t.isStringLiteral(node) &&
+      (inclusive ? node.value.length >= min : node.value.length > min) &&
+      (inclusive ? node.value.length <= max : node.value.length < max)
+    ) {
+      return node.value;
+    }
+    throw new ParseError(
+      node,
+      `string does not have a length between ${min} and ${max}, ${
+        inclusive ? "inclusive" : "non-inclusive"
+      }`
+    );
+  }
+);
+
+z.inRangeString(5, 100, true).parse(stringNode); // will pass and return the string value
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -58,32 +58,32 @@ matches an **exact** object of shape:
 - `z.custom` allows creating ad-hoc parsers.
 
 ```ts
-const z: Zast = new Zast({
-  fileContent: 'const str = "pretend very long str"',
-});
-
-z.custom(
-  "inRangeString",
-  (
-    ctx,
-    node,
-    min: number = 0,
-    max: number = 50,
-    inclusive: boolean = false
-  ) => {
-    if (
-      t.isStringLiteral(node) &&
-      (inclusive ? node.value.length >= min : node.value.length > min) &&
-      (inclusive ? node.value.length <= max : node.value.length < max)
-    ) {
-      return node.value;
-    }
-    throw new ParseError(
+const z = Zast(
+  {
+    fileContent: 'const longStr = "pretend very long str"',
+  },
+  {
+    inRangeString: (
+      ctx,
       node,
-      `string does not have a length between ${min} and ${max}, ${
-        inclusive ? "inclusive" : "non-inclusive"
-      }`
-    );
+      min: number = 0,
+      max: number = 50,
+      inclusive: boolean = false
+    ) => {
+      if (
+        t.isStringLiteral(node) &&
+        (inclusive ? node.value.length >= min : node.value.length > min) &&
+        (inclusive ? node.value.length <= max : node.value.length < max)
+      ) {
+        return node.value;
+      }
+      throw new ParseError(
+        node,
+        `string does not have a length between ${min} and ${max}, ${
+          inclusive ? "inclusive" : "non-inclusive"
+        }`
+      );
+    },
   }
 );
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "type": "module",
   "scripts": {
-    "test-types": "vitest run --typecheck.only",
+    "test:types": "vitest run --typecheck.only",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "type": "module",
   "scripts": {
     "test-types": "vitest run --typecheck.only",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "exports": "./index.ts",
   "engines": {

--- a/src/__tests__/babel.test.ts
+++ b/src/__tests__/babel.test.ts
@@ -8,7 +8,9 @@ import { ParseError } from "../babel/utils";
 describe("babel defaults", () => {
   describe("z.string()", () => {
     it("should pass for any string", () => {
-      const { z, file } = getTestBabelInstance("const data = {name: 'john'}");
+      const { z, file } = getTestBabelInstance({
+        fileContent: "const data = {name: 'john'}",
+      });
       let node: t.Node | undefined;
       traverse(file, {
         StringLiteral(path) {
@@ -18,7 +20,9 @@ describe("babel defaults", () => {
       expect(z.string().parse(node!)).toBe("john");
     });
     it("should throw if type is not string", () => {
-      const { z, file } = getTestBabelInstance("const data = {name: 2}");
+      const { z, file } = getTestBabelInstance({
+        fileContent: "const data = {name: 2}",
+      });
       let node: t.Node | undefined;
       traverse(file, {
         NumericLiteral(path) {
@@ -29,7 +33,9 @@ describe("babel defaults", () => {
       expect(z.string().parse.bind(null, node!)).toThrow();
     });
     it("should pass for a string with specific value", () => {
-      const { z, file } = getTestBabelInstance("const data = {name: 'andy'}");
+      const { z, file } = getTestBabelInstance({
+        fileContent: "const data = {name: 'andy'}",
+      });
       let node: t.Node | undefined;
       traverse(file, {
         StringLiteral(path) {
@@ -39,7 +45,9 @@ describe("babel defaults", () => {
       expect(z.string("andy").parse(node!)).toBe("andy");
     });
     it("should throw for a string with specific value if string contains a different value", () => {
-      const { z, file } = getTestBabelInstance("const data = {name: 'andy'}");
+      const { z, file } = getTestBabelInstance({
+        fileContent: "const data = {name: 'andy'}",
+      });
       let node: t.Node | undefined;
       traverse(file, {
         StringLiteral(path) {
@@ -52,7 +60,9 @@ describe("babel defaults", () => {
   });
   describe("z.number()", () => {
     it("should pass for any number", () => {
-      const { z, file } = getTestBabelInstance("const data = {age: 22}");
+      const { z, file } = getTestBabelInstance({
+        fileContent: "const data = {age: 22}",
+      });
       let node: t.Node | undefined;
       traverse(file, {
         NumericLiteral(path) {
@@ -62,7 +72,9 @@ describe("babel defaults", () => {
       expect(z.number().parse(node!)).toBe(22);
     });
     it("should throw if type is not number", () => {
-      const { z, file } = getTestBabelInstance("const data = {age: true}");
+      const { z, file } = getTestBabelInstance({
+        fileContent: "const data = {age: true}",
+      });
       let node: t.Node | undefined;
       traverse(file, {
         BooleanLiteral(path) {
@@ -73,7 +85,9 @@ describe("babel defaults", () => {
       expect(z.number().parse.bind(null, node!)).toThrow();
     });
     it("should pass for a number with specific value", () => {
-      const { z, file } = getTestBabelInstance("const data = {age: 30}");
+      const { z, file } = getTestBabelInstance({
+        fileContent: "const data = {age: 30}",
+      });
       let node: t.Node | undefined;
       traverse(file, {
         NumericLiteral(path) {
@@ -83,7 +97,9 @@ describe("babel defaults", () => {
       expect(z.number(30).parse(node!)).toBe(30);
     });
     it("should throw for a number with specific value if number contains a different value", () => {
-      const { z, file } = getTestBabelInstance("const data = {age: 30}");
+      const { z, file } = getTestBabelInstance({
+        fileContent: "const data = {age: 30}",
+      });
       let node: t.Node | undefined;
       traverse(file, {
         NumericLiteral(path) {
@@ -95,9 +111,9 @@ describe("babel defaults", () => {
     });
     describe("z.boolean()", () => {
       it("should pass for any boolean", () => {
-        const { z, file } = getTestBabelInstance(
-          "const data = {isAdmin: true}"
-        );
+        const { z, file } = getTestBabelInstance({
+          fileContent: "const data = {isAdmin: true}",
+        });
         let node: t.Node | undefined;
         traverse(file, {
           BooleanLiteral(path) {
@@ -107,7 +123,9 @@ describe("babel defaults", () => {
         expect(z.boolean().parse(node!)).toBe(true);
       });
       it("should throw if type is not boolean", () => {
-        const { z, file } = getTestBabelInstance("const data = {isAdmin: 20}");
+        const { z, file } = getTestBabelInstance({
+          fileContent: "const data = {isAdmin: 20}",
+        });
         let node: t.Node | undefined;
         traverse(file, {
           BooleanLiteral(path) {
@@ -118,9 +136,9 @@ describe("babel defaults", () => {
         expect(z.boolean().parse.bind(null, node!)).toThrow();
       });
       it("should pass for a boolean with specific value", () => {
-        const { z, file } = getTestBabelInstance(
-          "const data = {isAdmin: false}"
-        );
+        const { z, file } = getTestBabelInstance({
+          fileContent: "const data = {isAdmin: false}",
+        });
         let node: t.Node | undefined;
         traverse(file, {
           BooleanLiteral(path) {
@@ -130,9 +148,9 @@ describe("babel defaults", () => {
         expect(z.boolean(false).parse(node!)).toBe(false);
       });
       it("should throw for a boolean with specific value if boolean contains a different value", () => {
-        const { z, file } = getTestBabelInstance(
-          "const data = {isAdmin: false}"
-        );
+        const { z, file } = getTestBabelInstance({
+          fileContent: "const data = {isAdmin: false}",
+        });
         let node: t.Node | undefined;
         traverse(file, {
           BooleanLiteral(path) {
@@ -148,9 +166,9 @@ describe("babel defaults", () => {
   describe("z.function()", () => {
     it("should pass for a sync function", () => {
       let node: t.Node | undefined;
-      const { z, file } = getTestBabelInstance(
-        "const user = {getSession: function() {}}"
-      );
+      const { z, file } = getTestBabelInstance({
+        fileContent: "const user = {getSession: function() {}}",
+      });
       traverse(file, {
         FunctionExpression(path) {
           node = path.node;
@@ -161,9 +179,9 @@ describe("babel defaults", () => {
     });
     it("should pass for an async function", () => {
       let node: t.Node | undefined;
-      const { z, file } = getTestBabelInstance(
-        "const user = {getSession: async function() {}}"
-      );
+      const { z, file } = getTestBabelInstance({
+        fileContent: "const user = {getSession: async function() {}}",
+      });
       traverse(file, {
         FunctionExpression(path) {
           node = path.node;
@@ -174,9 +192,10 @@ describe("babel defaults", () => {
     });
     it("should pass with function code if code is passed on", () => {
       let node: t.Node | undefined;
-      const { z, file } = getTestBabelInstance(
-        "const user = {getSession: function() {return Promise.resolve(2)}}"
-      );
+      const { z, file } = getTestBabelInstance({
+        fileContent:
+          "const user = {getSession: function() {return Promise.resolve(2)}}",
+      });
       traverse(file, {
         FunctionExpression(path) {
           node = path.node;
@@ -191,7 +210,9 @@ describe("babel defaults", () => {
   describe("z.array()", () => {
     it("should parse single type of elemens in array", () => {
       let node: t.Node | undefined;
-      const { z, file } = getTestBabelInstance("const arr = [1,2,3]");
+      const { z, file } = getTestBabelInstance({
+        fileContent: "const arr = [1,2,3]",
+      });
       traverse(file, {
         ArrayExpression(path) {
           node = path.node;
@@ -203,7 +224,9 @@ describe("babel defaults", () => {
     });
     it("should parse multiple types of elemens in array", () => {
       let node: t.Node | undefined;
-      const { z, file } = getTestBabelInstance("const arr = [1,'a', true]");
+      const { z, file } = getTestBabelInstance({
+        fileContent: "const arr = [1,'a', true]",
+      });
       traverse(file, {
         ArrayExpression(path) {
           node = path.node;
@@ -219,7 +242,9 @@ describe("babel defaults", () => {
     });
     it("should parse any array", () => {
       let node: t.Node | undefined;
-      const { z, file } = getTestBabelInstance("const arr = [1,'a', true]");
+      const { z, file } = getTestBabelInstance({
+        fileContent: "const arr = [1,'a', true]",
+      });
       traverse(file, {
         ArrayExpression(path) {
           node = path.node;
@@ -231,9 +256,9 @@ describe("babel defaults", () => {
     // Question for API design, how should this behave?
     it.skip("should parse nested arrays", () => {
       let node: t.Node | undefined;
-      const { z, file } = getTestBabelInstance(
-        "const arr = [1,[2,[3],[4,[5]]]]"
-      );
+      const { z, file } = getTestBabelInstance({
+        fileContent: "const arr = [1,[2,[3],[4,[5]]]]",
+      });
       traverse(file, {
         ArrayExpression(path) {
           if (!node) {
@@ -250,9 +275,9 @@ describe("babel defaults", () => {
   describe("z.tuple()", () => {
     it("should parse tuples", () => {
       let node: t.Node | undefined;
-      const { z, file } = getTestBabelInstance(
-        "const arr = ['John Doe', 32, true]"
-      );
+      const { z, file } = getTestBabelInstance({
+        fileContent: "const arr = ['John Doe', 32, true]",
+      });
       traverse(file, {
         ArrayExpression(path) {
           node = path.node;
@@ -270,7 +295,7 @@ describe("babel defaults", () => {
       let node: t.Node | undefined;
       const fileContent =
         "const obj = {str: 'str', num: 2, bool: false, test: () => {}, arr: [1,2]}";
-      const { z, file } = getTestBabelInstance(fileContent);
+      const { z, file } = getTestBabelInstance({ fileContent });
       traverse(file, {
         ObjectExpression(path) {
           node = path.node;
@@ -305,7 +330,7 @@ describe("babel defaults", () => {
             },
           },
         }`;
-      const { z, file } = getTestBabelInstance(fileContent);
+      const { z, file } = getTestBabelInstance({ fileContent });
       traverse(file, {
         ObjectExpression(path) {
           // We only want the root object
@@ -344,7 +369,7 @@ describe("babel defaults", () => {
         arr: [1, 2],
         test: () => {}
       };`;
-      const { z, file } = getTestBabelInstance(fileContent);
+      const { z, file } = getTestBabelInstance({ fileContent });
       traverse(file, {
         ObjectExpression(path) {
           node = path.node;
@@ -364,7 +389,7 @@ describe("babel defaults", () => {
     it("should return a union type of parsed values from provided schemas", () => {
       let node: t.Node | undefined;
       const fileContent = `const value = [1,'a',true,[1,2,3],{id: 'ss'}]`;
-      const { z, file } = getTestBabelInstance(fileContent);
+      const { z, file } = getTestBabelInstance({ fileContent });
       traverse(file, {
         ArrayExpression(path) {
           // We only want the root object
@@ -387,17 +412,23 @@ describe("babel defaults", () => {
 
 describe("babel custom parser", () => {
   it("should allow creating custom parsers", () => {
-    const z: Zast = new Zast({
-      fileContent: 'const longStr = "pretend very long str"',
-    });
-    const file = babel.parse('const longStr = "pretend very long str"');
-
-    z.custom("minLenString", (ctx, node, len: number = 10) => {
-      if (t.isStringLiteral(node) && node.value.length > len) {
-        return node.value;
+    const z = Zast(
+      {
+        fileContent: 'const longStr = "pretend very long str"',
+      },
+      {
+        minLenString: (ctx, node, len: number = 10) => {
+          if (t.isStringLiteral(node) && node.value.length > len) {
+            return node.value;
+          }
+          throw new ParseError(
+            node,
+            `string is less than ${len} characters long`
+          );
+        },
       }
-      throw new ParseError(node, `string is less than ${len} characters long`);
-    });
+    );
+    const file = babel.parse('const longStr = "pretend very long str"');
 
     let node: t.Node | undefined;
     traverse(file, {
@@ -412,35 +443,36 @@ describe("babel custom parser", () => {
   });
 
   it("should allow creating custom parsers", () => {
-    const z: Zast = new Zast({
-      fileContent: 'const longStr = "pretend very long str"',
-    });
-    const file = babel.parse('const longStr = "pretend very long str"');
-
-    z.custom(
-      "inRangeString",
-      (
-        ctx,
-        node,
-        min: number = 0,
-        max: number = 50,
-        inclusive: boolean = false
-      ) => {
-        if (
-          t.isStringLiteral(node) &&
-          (inclusive ? node.value.length >= min : node.value.length > min) &&
-          (inclusive ? node.value.length <= max : node.value.length < max)
-        ) {
-          return node.value;
-        }
-        throw new ParseError(
+    const z = Zast(
+      {
+        fileContent: 'const longStr = "pretend very long str"',
+      },
+      {
+        inRangeString: (
+          ctx,
           node,
-          `string does not have a length between ${min} and ${max}, ${
-            inclusive ? "inclusive" : "non-inclusive"
-          }`
-        );
+          min: number = 0,
+          max: number = 50,
+          inclusive: boolean = false
+        ) => {
+          if (
+            t.isStringLiteral(node) &&
+            (inclusive ? node.value.length >= min : node.value.length > min) &&
+            (inclusive ? node.value.length <= max : node.value.length < max)
+          ) {
+            return node.value;
+          }
+          throw new ParseError(
+            node,
+            `string does not have a length between ${min} and ${max}, ${
+              inclusive ? "inclusive" : "non-inclusive"
+            }`
+          );
+        },
       }
     );
+
+    const file = babel.parse('const longStr = "pretend very long str"');
 
     let node: t.Node | undefined;
     traverse(file, {

--- a/src/__tests__/babel.test.ts
+++ b/src/__tests__/babel.test.ts
@@ -387,7 +387,7 @@ describe("babel defaults", () => {
 
 describe("babel custom parser", () => {
   it("should allow creating custom parsers", () => {
-    const z: Zast<{ fileContent: string }> = new Zast({
+    const z: Zast = new Zast({
       fileContent: 'const longStr = "pretend very long str"',
     });
     const file = babel.parse('const longStr = "pretend very long str"');
@@ -412,7 +412,7 @@ describe("babel custom parser", () => {
   });
 
   it("should allow creating custom parsers", () => {
-    const z: Zast<{ fileContent: string }> = new Zast({
+    const z: Zast = new Zast({
       fileContent: 'const longStr = "pretend very long str"',
     });
     const file = babel.parse('const longStr = "pretend very long str"');

--- a/src/__tests__/types.test-d.ts
+++ b/src/__tests__/types.test-d.ts
@@ -1,11 +1,11 @@
 import { expectTypeOf } from "vitest";
 import { getTestBabelInstance } from "../testUtils";
-import { isStringLiteral } from "@babel/types";
+import { isNumericLiteral, isStringLiteral } from "@babel/types";
 import { Zast } from "../babel/zast";
 import { ZastContext } from "../babel/types";
 
 describe("z.", () => {
-  const { z } = getTestBabelInstance("");
+  const { z } = getTestBabelInstance({ fileContent: "" });
   it("z.string() should pass a string output", () => {
     expectTypeOf(z.string().parse).returns.toBeString();
   });
@@ -75,38 +75,45 @@ describe("z.", () => {
     // ).returns.toEqualTypeOf<string>;
   });
   it("z.custom should infer correct args and return values based on the passed parser", () => {
-    const _z: Zast<ZastContext> = z;
-    _z.custom("minLenString", (ctx, node, len?: number) => {
-      if (
-        isStringLiteral(node) &&
-        len != undefined &&
-        node.value.length > len
-      ) {
-        return node.value;
-      }
-    });
-
-    expectTypeOf(_z.minLenString).parameters.toEqualTypeOf<[len?: number]>();
-    expectTypeOf(_z.minLenString().parse).returns.toEqualTypeOf<string>;
-  });
-  it("z.custom should infer correct args and return values based on the passed parser", () => {
-    const _z: Zast<ZastContext> = z;
-    _z.custom(
-      "inRangeString",
-      (
-        ctx,
-        node,
-        min: number = 0,
-        max: number = 50,
-        inclusive: boolean = false
-      ) => {
-        return isStringLiteral(node) ? node.value : undefined;
+    const z = Zast(
+      { fileContent: "" },
+      {
+        minLenString: (ctx, node, len: number = 10) => {
+          if (
+            isStringLiteral(node) &&
+            len != undefined &&
+            node.value.length > len
+          ) {
+            return node.value;
+          }
+        },
       }
     );
 
-    expectTypeOf(_z.inRangeString).parameters.toEqualTypeOf<
+    expectTypeOf(z.minLenString).parameters.toEqualTypeOf<[len?: number]>();
+    expectTypeOf(z.minLenString().parse).returns.toEqualTypeOf<string>;
+  });
+  it("z.custom should infer correct args and return values based on the passed parser", () => {
+    const z = Zast(
+      { fileContent: "" },
+      {
+        isInRangeNumber: (
+          ctx,
+          node,
+          min: number = 0,
+          max: number = 50,
+          inclusive: boolean = false
+        ) => {
+          return isNumericLiteral(node) && node.value;
+        },
+      }
+    );
+
+    expectTypeOf(z.isInRangeNumber).toEqualTypeOf<{ fileContent: string }>;
+
+    expectTypeOf(z.isInRangeNumber).parameters.toEqualTypeOf<
       [min?: number, max?: number, inclusive?: boolean]
     >();
-    expectTypeOf(_z.inRangeString().parse).returns.toEqualTypeOf<string>;
+    expectTypeOf(z.isInRangeNumber().parse).returns.toEqualTypeOf<string>;
   });
 });

--- a/src/__tests__/types.test-d.ts
+++ b/src/__tests__/types.test-d.ts
@@ -1,5 +1,8 @@
 import { expectTypeOf } from "vitest";
 import { getTestBabelInstance } from "../testUtils";
+import { isStringLiteral } from "@babel/types";
+import { Zast } from "../babel/zast";
+import { ZastContext } from "../babel/types";
 
 describe("z.", () => {
   const { z } = getTestBabelInstance("");
@@ -70,5 +73,40 @@ describe("z.", () => {
     //     }),
     //   ]).parse
     // ).returns.toEqualTypeOf<string>;
+  });
+  it("z.custom should infer correct args and return values based on the passed parser", () => {
+    const _z: Zast<ZastContext> = z;
+    _z.custom("minLenString", (ctx, node, len?: number) => {
+      if (
+        isStringLiteral(node) &&
+        len != undefined &&
+        node.value.length > len
+      ) {
+        return node.value;
+      }
+    });
+
+    expectTypeOf(_z.minLenString).parameters.toEqualTypeOf<[len?: number]>();
+    expectTypeOf(_z.minLenString().parse).returns.toEqualTypeOf<string>;
+  });
+  it("z.custom should infer correct args and return values based on the passed parser", () => {
+    const _z: Zast<ZastContext> = z;
+    _z.custom(
+      "inRangeString",
+      (
+        ctx,
+        node,
+        min: number = 0,
+        max: number = 50,
+        inclusive: boolean = false
+      ) => {
+        return isStringLiteral(node) ? node.value : undefined;
+      }
+    );
+
+    expectTypeOf(_z.inRangeString).parameters.toEqualTypeOf<
+      [min?: number, max?: number, inclusive?: boolean]
+    >();
+    expectTypeOf(_z.inRangeString().parse).returns.toEqualTypeOf<string>;
   });
 });

--- a/src/babel/any.ts
+++ b/src/babel/any.ts
@@ -5,6 +5,8 @@ import { parseString } from "./string";
 import { Parser, ZastContext } from "./types";
 import { ParseError } from "./utils";
 import parseArray from "./array";
+import { parseObject } from "./object";
+import parseFunction from "./function";
 
 export function parseAny<C extends ZastContext>(context: C): Parser<any> {
   return {
@@ -27,9 +29,12 @@ export function parseAny<C extends ZastContext>(context: C): Parser<any> {
       if (t.isArrayExpression(node)) {
         return parseArray(context).parse(node);
       }
-      //   if (t.isObjectExpression(node)) {
-      //     return parseObject(context).parse(node);
-      //   }
+      if (t.isObjectExpression(node)) {
+        return parseObject(context).parse(node);
+      }
+      if (t.isFunctionExpression(node) || t.isArrowFunctionExpression(node)) {
+        return parseFunction(context).parse(node);
+      }
     },
   };
 }

--- a/src/babel/union.ts
+++ b/src/babel/union.ts
@@ -1,11 +1,7 @@
 import { Parser, ZastContext } from "./types";
 import { ParseError } from "./utils";
-import t from "@babel/types";
 
-export default function defaultUnionParser<
-  C extends ZastContext,
-  I extends Array<unknown>
->(
+export function parseUnion<C extends ZastContext, I extends Array<unknown>>(
   context: C,
   options: {
     membersSchema: [...{ [key in keyof I]: Parser<I[key]> }];

--- a/src/babel/zast.ts
+++ b/src/babel/zast.ts
@@ -25,16 +25,22 @@ export class Zast<
 
   custom<
     TName extends string,
-    TArgs,
+    TArgs extends unknown[],
     TVal
     // TBody extends (ctx: Context, node: Node, ...args: unknown[]) => unknown
   >(
     name: TName,
-    body: (ctx: Context, node: Node, ...args: TArgs[]) => TVal
-  ): asserts this is { [K in TName]: (...args: TArgs[]) => Parser<TVal> } {
+    body: (
+      ctx: Context,
+      node: Node,
+      ...args: [...{ [key in keyof TArgs]: TArgs[key] }]
+    ) => TVal
+  ): asserts this is { [K in TName]: (...args: TArgs) => Parser<TVal> } {
     const ctx = this.context;
 
-    (this as any)[name] = (...args: TArgs[]): Parser<TVal> => ({
+    (this as any)[name] = (
+      ...args: [...{ [key in keyof TArgs]: TArgs[key] }]
+    ): Parser<TVal> => ({
       parse(node) {
         return body(ctx, node, ...args);
       },

--- a/src/babel/zast.ts
+++ b/src/babel/zast.ts
@@ -11,7 +11,6 @@ import parseTuple from "./tuple";
 import { Parser, ZastContext } from "./types";
 import defaultUnionParser from "./union";
 
-type ReturnTypeInferer<T> = T extends (...args: any[]) => infer U ? U : never;
 export class Zast<
   Context extends ZastContext
   // CustomParsers extends Record<string, Parser<unknown>["parse"]>

--- a/src/babel/zast.ts
+++ b/src/babel/zast.ts
@@ -11,24 +11,13 @@ import parseTuple from "./tuple";
 import { Parser, ZastContext } from "./types";
 import defaultUnionParser from "./union";
 
-export class Zast<
-  Context extends ZastContext
-  // CustomParsers extends Record<string, Parser<unknown>["parse"]>
-> {
+export class Zast<Context extends ZastContext = ZastContext> {
   private context: Context;
-  constructor(
-    context: Context
-    // customParsers?: CustomParsers
-  ) {
+  constructor(context: Context) {
     this.context = context;
   }
 
-  custom<
-    TName extends string,
-    TArgs extends unknown[],
-    TVal
-    // TBody extends (ctx: Context, node: Node, ...args: unknown[]) => unknown
-  >(
+  custom<TName extends string, TArgs extends unknown[], TVal>(
     name: TName,
     body: (
       ctx: Context,

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -1,10 +1,8 @@
 import { Zast } from "./babel/zast";
 import babel from "@babel/parser";
 
-export function getTestBabelInstance(fileContent: string) {
-  const z = new Zast({
-    fileContent,
-  });
-  const file = babel.parse(fileContent);
+export function getTestBabelInstance(...args: Parameters<typeof Zast>) {
+  const z = Zast(...args);
+  const file = babel.parse(args[0].fileContent);
   return { z, file };
 }


### PR DESCRIPTION
Custom parsers allow adding ad-hoc parsers per need. The types for their parameters and return value are inferred by Zast automatically.

Example:

```ts
const z = Zast(
  {
    fileContent: 'const longStr = "pretend very long str"',
  },
  {
    inRangeString: (
      ctx,
      node,
      min: number = 0,
      max: number = 50,
      inclusive: boolean = false,
    ) => {
      if (
        t.isStringLiteral(node) &&
        (inclusive ? node.value.length >= min : node.value.length > min) &&
        (inclusive ? node.value.length <= max : node.value.length < max)
      ) {
        return node.value;
      }
      throw new ParseError(
        node,
        `string does not have a length between ${min} and ${max}, ${
          inclusive ? "inclusive" : "non-inclusive"
        }`,
      );
    },
  },
);

z.inRangeString(5, 100, true).parse(StringNode)
```